### PR TITLE
Fix force sign in SPICE dataset

### DIFF
--- a/src/jmp/datasets/finetune/spice.py
+++ b/src/jmp/datasets/finetune/spice.py
@@ -143,6 +143,9 @@ class SPICE(LmdbDataset[T]):
                         np.array(_assert_dataset(mol.get("conformations"))[conf_idx])
                     ).float()  # n_atoms 3
 
+                    # Fix force sign. See https://github.com/facebookresearch/JMP/issues/1#issue-2341357453 for details
+                    force = -force
+
                     data_object = Data(
                         atomic_numbers=atomic_numbers,
                         pos=pos,


### PR DESCRIPTION
As reported by @tkreiman in issue "SPICE fine-tuning trains to Energy gradient not Force #1", SPICE's `dft_total_gradient` is the positive gradient and needs to be negated to get forces.